### PR TITLE
add missing comma in syntax definition

### DIFF
--- a/codestyle.tex
+++ b/codestyle.tex
@@ -31,7 +31,7 @@
 	sensitive=false,
 	morecomment=[l]{//}, 
 	morecomment=[s]{(*}{*)},
-	morestring=[b]"
+	morestring=[b]",
 	morestring=[b]'
 }
 


### PR DESCRIPTION
at the moment strings were not proberly highlighted, because there is a comma missing in the syntax definition